### PR TITLE
Fix pip 10 errors and directory error

### DIFF
--- a/nanopolish_on_NCI
+++ b/nanopolish_on_NCI
@@ -4,10 +4,10 @@ mkdir -p /short/sd34/ap5514/myapps/nanopolish/0.9.0
 export PYTHONPATH=/short/sd34/ap5514/myapps/nanopolish/0.9.0/lib/python3.6/site-packages
 mkdir -p $PYTHONPATH
 export PATH=/short/sd34/ap5514/myapps/nanopolish/0.9.0/bin:$PATH
-pip3 install biopython --upgrade pip --prefix /short/sd34/ap5514/myapps/nanopolish/0.9.0 --ignore-installed
+python3 -m pip install biopython --upgrade pip --prefix /short/sd34/ap5514/myapps/nanopolish/0.9.0 --ignore-installed
 
 # install pysam
-pip3 install pysam --upgrade pip --prefix /short/sd34/ap5514/myapps/nanopolish/0.9.0 --ignore-installed
+python3 -m pip install pysam --upgrade pip --prefix /short/sd34/ap5514/myapps/nanopolish/0.9.0 --ignore-installed
 
 #load all the required modules incluing gcc-4.8+ and eigen and hdf5 and hts
 module load gcc/4.9.0
@@ -16,7 +16,7 @@ module load eigen/3.2.8
 module load htslib/1.4
 
 #install nanopolish
-cd /short/sd34/ap5514/myapps/nanopolish/0.9.0/bin/nanopolish # make sure nanopolish files are sent to the right folder
+cd /short/sd34/ap5514/myapps/nanopolish/0.9.0/bin/ # make sure nanopolish files are sent to the right folder
 git clone --recursive https://github.com/jts/nanopolish.git
 cd nanopolish
 make EIGEN=noinstall HTS=noinstall # HDF5=noinstall flag was not used because NCI didn't have threadsafe hdf5 installed


### PR DESCRIPTION
pip3 no longer works when updated (see https://github.com/pypa/pip/issues/5221). Also, git clone should create the right folder (or you need to mkdir it first)